### PR TITLE
Fix for issue where not building in us-east-1

### DIFF
--- a/templates/datarobot-existing-vpc.template.yaml
+++ b/templates/datarobot-existing-vpc.template.yaml
@@ -312,7 +312,7 @@ Resources:
         Encrypted: true
         EncryptionKey: ' '
         SSHKey: !Ref KeyPairName
-        QSInstallationBucket: !Ref QSS3BucketName
+        QSInstallationBucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
         # DRInstallationBucket: !Ref DRS3InstallationBucket
         DRInstallationBucket: !If [CreateS3BucketCondition, !Ref 'S3Bucket', !Ref DRS3InstallationBucket]
         ImageId: !FindInMap [RegionMap, !Ref "AWS::Region", Centos]


### PR DESCRIPTION
Fix for issue where not building in us-east-1 - the bucket reference for downloading the config.yaml file needs to be calculated to the local quickstart bucket.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
